### PR TITLE
fix(dod): validate PROFILE env before generate_config_fragment

### DIFF
--- a/DoD/disa_stig_helper.py
+++ b/DoD/disa_stig_helper.py
@@ -16,7 +16,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from utils.kernel_config_profiles import generate_config_fragment
+from utils.kernel_config_profiles import KERNEL_PROFILES, generate_config_fragment
+
+PROFILE_CHOICES = tuple(KERNEL_PROFILES.keys())
 
 
 DISTRO_PROFILES = {
@@ -124,7 +126,16 @@ def print_guidance(context: dict[str, str]) -> None:
 def generate_secure_config(output: Path, requested_distro: str | None, requested_profile: str | None) -> int:
     """Generate a distro-aware kernel config fragment and return 0 on success."""
     context = detect_distro(requested_distro)
-    profile = requested_profile or os.environ.get("PROFILE") or context["default_profile"]
+    env_profile = os.environ.get("PROFILE")
+    profile = requested_profile or env_profile or context["default_profile"]
+    if profile not in KERNEL_PROFILES:
+        available = ", ".join(PROFILE_CHOICES)
+        source = "PROFILE environment variable" if env_profile and not requested_profile else "profile"
+        print(
+            f"✗ Unknown {source}: {profile!r}. Available profiles: {available}",
+            file=sys.stderr,
+        )
+        return 1
     config_text, warnings = generate_config_fragment(profile)
 
     header = [
@@ -184,7 +195,7 @@ def main() -> int:
 
     config_parser = subparsers.add_parser("generate-secure-config", help="Generate a distro-aware secure kernel config fragment")
     config_parser.add_argument("--distro", help="Override distro detection for generation")
-    config_parser.add_argument("--profile", choices=["permissive", "balanced", "hardened"], help="Kernel config profile")
+    config_parser.add_argument("--profile", choices=PROFILE_CHOICES, help="Kernel config profile")
     config_parser.add_argument("--output", default=os.environ.get("OUTPUT", str(REPO_ROOT / "out" / "dod" / "secure_kernel.config")), help="Output file")
 
     args = parser.parse_args()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

`PROFILE` from the environment was bypassing the `argparse` `choices` configured on `--profile` in `dod-secure-config`. When `PROFILE` held an invalid value (e.g. `PROFILE=bogus`), it flowed straight into `generate_config_fragment()`, which raised an uncaught `ValueError`. As a result the CLI exited with a Python traceback instead of a friendly error message.

This change validates the resolved profile name before invoking `generate_config_fragment()` and sources the argparse `choices` from `KERNEL_PROFILES` so the CLI and env-var validation cannot drift apart.

- [ ] Breaking change?
- [x] Impacts security?
  - Hardens input handling on a DoD/DISA STIG compliance helper. No cryptographic change, but invalid inputs now fail closed with a clear error instead of an uncaught exception.
- [ ] Includes tests?

## How This Was Tested

Manual reproduction and verification against `DoD/disa_stig_helper.py generate-secure-config`:

| Scenario | Before | After |
| --- | --- | --- |
| `PROFILE=bogus` (no `--profile`) | `Traceback ... ValueError: Unknown profile: bogus`, exit 1 | `✗ Unknown PROFILE environment variable: 'bogus'. Available profiles: permissive, hardened, balanced`, exit 1 |
| `PROFILE=balanced` (no `--profile`) | OK | OK (unchanged) |
| `--profile nope` | argparse rejects with usage, exit 2 | argparse rejects with usage, exit 2 (unchanged) |
| `PROFILE=bogus --profile hardened` | OK (arg wins) | OK (arg wins, unchanged) |

The argparse `choices` for `--profile` are now derived from `KERNEL_PROFILES.keys()` so adding a new profile in `utils/kernel_config_profiles.py` automatically makes it available in the CLI without a second edit here.

## Integration Instructions

N/A — stacked on top of #218 (`copilot/add-dod-compliance-helper`). Merge that PR first; this fix targets the same branch so it can be folded in before the feature merges to `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6906179-ba77-457a-8f36-cf459b53818a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6906179-ba77-457a-8f36-cf459b53818a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

