### PR TITLE
fix(phoenix-boot): resolve symlinks when computing SCRIPT_DIR

### DIFF
--- a/phoenix-boot
+++ b/phoenix-boot
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 exec "${SCRIPT_DIR}/phoenixboot" "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `phoenix-boot` shim derived `SCRIPT_DIR` from `BASH_SOURCE[0]` without resolving symlinks. When the shim is installed via a symlink (for example `/usr/local/bin/phoenix-boot -> /opt/PhoenixBoot/phoenix-boot`), `SCRIPT_DIR` resolves to the symlink's parent directory (`/usr/local/bin`), so the subsequent `exec "${SCRIPT_DIR}/phoenixboot"` fails because `phoenixboot` does not live alongside the symlink.

`phoenixboot` itself already handles this correctly by running `realpath` on `BASH_SOURCE[0]` before taking `dirname` (see `phoenixboot:78-80`). This change applies the same pattern to the shim.

## Change

```3:6:phoenix-boot
SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
exec "${SCRIPT_DIR}/phoenixboot" "$@"
```

## Verification

- Direct invocation (`./phoenix-boot help`) continues to work.
- Symlinked invocation (`ln -s /workspace/phoenix-boot /tmp/phoenix-boot-symlink && /tmp/phoenix-boot-symlink help`) now succeeds; previously it would fail with `exec: /tmp/phoenixboot: not found`.

## Affected files

- `phoenix-boot:3-5` (fixed)
- `phoenixboot:78-80` (reference implementation; unchanged)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-820d1305-38e6-44c8-b1b7-b1a7540e5a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-820d1305-38e6-44c8-b1b7-b1a7540e5a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

